### PR TITLE
修正了 openUrl 以直接调用 channel.call 打开链接

### DIFF
--- a/js-framework/src/betterncm-api/ncm.ts
+++ b/js-framework/src/betterncm-api/ncm.ts
@@ -36,20 +36,8 @@ export namespace ncm {
 		}
 	}
 
-	let cachedOpenURLFunc: Function | null = null;
 	export function openUrl(url: string) {
-		if (cachedOpenURLFunc === null) {
-			const findResult = findApiFunction("R$openUrl");
-			if (findResult) {
-				const [openUrl, openUrlRoot] = findResult;
-				cachedOpenURLFunc = openUrl.bind(openUrlRoot);
-			}
-		}
-		if (cachedOpenURLFunc === null) {
-			return null;
-		} else {
-			return cachedOpenURLFunc(url);
-		}
+		channel.call('os.navigateExternal', () => {}, [url]);
 	}
 
 	export function getNCMPackageVersion(): string {


### PR DESCRIPTION
如题，更加稳定
（其实是因为这几天好像更新了之前那个失效了）